### PR TITLE
Updating to newer leaflet and fixing es module imports

### DIFF
--- a/js/src/js/auth.js
+++ b/js/src/js/auth.js
@@ -1,5 +1,5 @@
 
-import Keycloak from "https://cdn.jsdelivr.net/npm/keycloak-js@26.0.7/lib/keycloak.min.js"
+import Keycloak from "keycloak";
 
 const initOptions = {
     url: 'https://usw2.auth.ac/auth', realm: 't27fr', clientId: 't27frapp', onLoad: 'login-required'

--- a/js/src/js/leaflet.js
+++ b/js/src/js/leaflet.js
@@ -1,40 +1,44 @@
+import L, {
+  Map,
+  TileLayer,
+  GeoJSON,
+  CircleMarker,
+} from "leaflet";
 
 /////////////////////////////////////////////////////////////////////
 //
 const createSellMap = (params) => {
-    // new rust code converts it to map so have to convert it back to
-    // JSON Object (or TODO:re-write all this)
-    //const params = Object.fromEntries(mapOfParams);
+  console.log("Creating Sell Map Report View");
+  // console.log(JSON.stringify(params.geoJson, ' ', '\t'));
 
-    console.log("Creating Sell Map Report View");
-    // JSON.stringify(params, ' ', '\t'));
+  const map = new Map(params.id).setView(params.centerPt, 12);
 
-    const map = L.map(params.id).setView(params.centerPt, 12);
+  new TileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution:
+      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+  }).addTo(map);
 
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        // maxZoom: 19,
-        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-    }).addTo(map);
+  if (params.geoJson) {
+    const geojsonMarkerOptions = {
+      radius: 8,
+      fillColor: "#ff7800",
+      color: "#000",
+      weight: 1,
+      opacity: 1,
+      fillOpacity: 0.8,
+    };
 
-    if (params.geoJson) {
-        const geojsonMarkerOptions = {
-            radius: 8,
-            fillColor: "#ff7800",
-            color: "#000",
-            weight: 1,
-            opacity: 1,
-            fillOpacity: 0.8
-        };
-
-        L.geoJSON(params.geoJson, {
-            pointToLayer: function (feature, latlng) {
-                return L.circleMarker(latlng, geojsonMarkerOptions);
+    new GeoJSON(params.geoJson,
+        {
+            pointToLayer: function (geoJsonPt, latlng) {
+                return new CircleMarker(latlng, geojsonMarkerOptions);
             }
-        }).addTo(map);
-    }
+        }
+    ).addTo(map);
 
-    return map;
+  }
 
+  return map;
 };
 
-export {createSellMap}
+export { createSellMap };

--- a/js/src/js/leaflet.js
+++ b/js/src/js/leaflet.js
@@ -1,5 +1,5 @@
 import L, {
-  Map,
+  Map as LeafletMap,
   TileLayer,
   GeoJSON,
   CircleMarker,
@@ -11,7 +11,7 @@ const createSellMap = (params) => {
   console.log("Creating Sell Map Report View");
   // console.log(JSON.stringify(params.geoJson, ' ', '\t'));
 
-  const map = new Map(params.id).setView(params.centerPt, 12);
+  const map = new LeafletMap(params.id).setView(params.centerPt, 12);
 
   new TileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     attribution:
@@ -28,14 +28,11 @@ const createSellMap = (params) => {
       fillOpacity: 0.8,
     };
 
-    new GeoJSON(params.geoJson,
-        {
-            pointToLayer: function (geoJsonPt, latlng) {
-                return new CircleMarker(latlng, geojsonMarkerOptions);
-            }
-        }
-    ).addTo(map);
-
+    new GeoJSON(params.geoJson, {
+      pointToLayer: function (geoJsonPt, latlng) {
+        return new CircleMarker(latlng, geojsonMarkerOptions);
+      },
+    }).addTo(map);
   }
 
   return map;

--- a/report_pages/src/components/report_sell_map.rs
+++ b/report_pages/src/components/report_sell_map.rs
@@ -8,7 +8,7 @@ use yew::prelude::*;
 pub struct Point(pub f64, pub f64);
 
 const SJV: Point = Point(30.5461096, -97.6723646);
-const SELLMAPID: &str = "sellMap";
+const SELL_MAP_ID: &str = "sellMap";
 
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
@@ -27,15 +27,15 @@ pub(crate) fn report_sell_view() -> Html {
                         log::info!("Downloading Geo Location data");
                         let resp = get_sales_geojson().await.unwrap();
                         log::info!("Report Data has been downloaded");
-                        report_state.set(ReportViewState::ReportHtmlGenerated(resp));
+                        report_state.set(ReportViewState::ReportHtmlGenerated(vec![resp]));
                     });
                 }
-                ReportViewState::ReportHtmlGenerated(geojson) => {
+                ReportViewState::ReportHtmlGenerated(json_list) => {
                     log::info!("Handling ReportHtmlGenerated");
                     if sell_map.borrow().is_none() {
                         *sell_map.borrow_mut() = create_sell_map(&serde_json::json!({
-                            "id": SELLMAPID,
-                            "geoJson": geojson,
+                            "id": SELL_MAP_ID,
+                            "geoJson": json_list[0],
                             "centerPt": SJV,
                         }));
                     }
@@ -51,7 +51,7 @@ pub(crate) fn report_sell_view() -> Html {
         ReportViewState::ReportHtmlGenerated(_) => {
             html! {
                 <div class="sale-map-container">
-                    <div id={SELLMAPID} />
+                    <div id={SELL_MAP_ID} />
                 </div>
             }
         }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -11,10 +11,10 @@
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black">
 
 
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/clocklet@0.3.0/css/clocklet.min.css" />
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet.css" crossorigin="" />
 
         <link href="https://cdn.datatables.net/v/bs5/jq-3.7.0/jszip-3.10.1/dt-2.2.1/b-3.2.1/b-colvis-3.2.1/b-html5-3.2.1/b-print-3.2.1/fh-4.0.1/r-3.0.3/sc-2.4.3/sb-1.8.1/sp-2.3.3/datatables.min.css" rel="stylesheet">
         <link href="https://cdn.datatables.net/2.2.1/css/dataTables.dataTables.css" rel="stylesheet">
@@ -72,7 +72,7 @@
         <link data-trunk rel="copy-file" href="src/static/robots.txt"/>
 
         <!-- Bootstrap JavaScript Bundle with Popper -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>o
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 
         <!-- Google Charts -->
         <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js" ></script>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -45,6 +45,15 @@
         <link rel="apple-touch-icon" sizes="384x384" href="/icon-384x384.png"/>
         <link rel="apple-touch-icon" sizes="512x512" href="/icon-512x512.png"/>
 
+        <script type="importmap">
+            {
+                "imports": {
+                    "leaflet": "https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet.js",
+                    "keycloak": "https://cdn.jsdelivr.net/npm/keycloak-js@26.2.0/lib/keycloak.min.js"
+                    
+                }
+            }
+        </script>
 
         <script>
             // register ServiceWorker
@@ -68,8 +77,7 @@
         <!-- Google Charts -->
         <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js" ></script>
 
-        <!-- Leaflet for sales map -->
-        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+
 
         <!-- Clocklet for delivery timecard -->
         <script type="text/javascript" crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/clocklet@0.3.0"></script>


### PR DESCRIPTION
- Updates to the 2.x leaflet.  
  - Currently, it is in alpha, but it is stable for the current use case.
- Fixes ES Module imports to be included on index page for better version management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated code to use ES module imports for Leaflet and Keycloak, improving consistency and modernizing library usage.
  - Adjusted handling of sales geojson data to return the full JSON response instead of just the features array.
  - Renamed internal constants for clarity and consistency.

- **Chores**
  - Updated import maps in the HTML to load Leaflet and Keycloak as ES modules from CDN.
  - Removed legacy script tag for Leaflet in the HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->